### PR TITLE
Fix for Ruby 3.0

### DIFF
--- a/lib/parser_combinator.rb
+++ b/lib/parser_combinator.rb
@@ -46,7 +46,7 @@ class ParserCombinator
     end
 
     def drop_while(&p)
-      Items.new(super(p))
+      Items.new(super(&p))
     end
 
     def flatten
@@ -70,7 +70,7 @@ class ParserCombinator
     end
 
     def take_while(&p)
-       Items.new(super(p))
+       Items.new(super(&p))
     end
 
     def uniq

--- a/lib/parser_combinator.rb
+++ b/lib/parser_combinator.rb
@@ -41,6 +41,42 @@ class ParserCombinator
   end
 
   class Items < Array
+    def drop(v)
+      Items.new(super(v))
+    end
+
+    def drop_while(&p)
+      Items.new(super(p))
+    end
+
+    def flatten
+      Items.new(super())
+    end
+
+    def slice(nth)
+      if nth.instance_of? Range then
+        Items.new(super(nth))
+      else
+        super(nth)
+      end
+    end
+
+    def slice(pos, len)
+      Items.new(super(pos, len))
+    end
+
+    def take(n)
+       Items.new(super(n))
+    end
+
+    def take_while(&p)
+       Items.new(super(p))
+    end
+
+    def uniq
+       Items.new(super())
+    end
+
     def head
       self.first
     end


### PR DESCRIPTION
A breaking change (Array always returning Array) in Ruby 3.0 hits the Items class.
See also: https://rubyreferences.github.io/rubychanges/3.0.html#array-always-returning-array